### PR TITLE
Fixed links to not include localhost:5173

### DIFF
--- a/client/src/mainpage.js
+++ b/client/src/mainpage.js
@@ -3,7 +3,7 @@ document.getElementById("username").textContent = username;
 
 function leftButtonClicked()
 {
-    const request1 = new Request("http://localhost:3000/console", {
+    const request1 = new Request("http://localhost:3000/console", { //CHANGE TO ADDRESS OF SERVER SIDE WHEN DEPLOYED
         method: "POST",
         headers: {
             "Content-Type": "application/json",
@@ -17,7 +17,7 @@ function leftButtonClicked()
 
 function rightButtonClicked()
 {
-    const request1 = new Request("http://localhost:3000/console", {
+    const request1 = new Request("http://localhost:3000/console", { //CHANGE TO ADDRESS OF SERVER SIDE WHEN DEPLOYED
         method: "POST",
         headers: {
             "Content-Type": "application/json",

--- a/client/src/pages/SignIn.jsx
+++ b/client/src/pages/SignIn.jsx
@@ -17,7 +17,7 @@ function SignInPage() {
       return;
     }
 
-    const request = new Request("http://localhost:3000/signIn", {
+    const request = new Request("http://localhost:3000/signIn", { //CHANGE TO ADDRESS OF SERVER SIDE WHEN DEPLOYED
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -37,13 +37,10 @@ function SignInPage() {
         }
         else {
           localStorage.setItem("username", name1);
-          window.location.href = "http://localhost:5173/dashboard";
+          window.location.href = "/dashboard";
           return;
       }
     })
-
-    // localStorage.setItem("username", name1);
-    // window.location.href = "http://localhost:5173/dashboard";
   }
 
   return(

--- a/client/src/pages/signuppage.jsx
+++ b/client/src/pages/signuppage.jsx
@@ -17,7 +17,7 @@ function SignUpInfo() {
     const [password, setPassword] = useState('');
 
     function signUpPressed() {
-        const request = new Request("http://localhost:3000/signup", {
+        const request = new Request("http://localhost:3000/signup", {//CHANGE TO ADDRESS OF SERVER SIDE WHEN DEPLOYED
             method: "POST",
             headers: {
                 "Content-Type": "application/json",
@@ -30,7 +30,7 @@ function SignUpInfo() {
             .then(text => {
                 console.log(text);
                 localStorage.setItem("username", name);
-                window.location.href = "http://localhost:5173/dashboard"; // Redirect after signup
+                window.location.href = "/dashboard"; // Redirect after signup
             })
             .catch(error => console.error('Error:', error));
     }

--- a/client/src/pages/swipePage.jsx
+++ b/client/src/pages/swipePage.jsx
@@ -8,7 +8,7 @@ function SwipePage() {
     const [currentIndex, setCurrentIndex] = useState(0); //track the current user
 
     useEffect(() => {
-        fetch("http://localhost:3000/users") //NEED A USERS ROUTE TO GET THE USERS!!!!!
+        fetch("http://localhost:3000/users") //NEED A USERS ROUTE TO GET THE USERS!!!!!   //CHANGE TO ADDRESS OF SERVER SIDE WHEN DEPLOYED
             .then((response) => response.json())
             .then((data) => {
                 setUsers(data);
@@ -34,7 +34,7 @@ function SwipePage() {
         //post request
         if (currentIndex < users.length) { //if still users to display
             const user = users[currentIndex]; 
-            const request1 = new Request("http://localhost:3000/swipePage", {
+            const request1 = new Request("http://localhost:3000/swipePage", { //CHANGE TO ADDRESS OF SERVER SIDE WHEN DEPLOYED
                 method: "POST",
                 headers: {
                     "Content-Type": "application/json",


### PR DESCRIPTION
Previously, links redirecting pages in the browser followed the format localhost:5173/pageName, when they should have just been /pageName. Closing issue #44 